### PR TITLE
Remove string freezes.

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,9 +15,9 @@ class PagesController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   # Specifies endpoint for connecting to the Microsoft Graph
-  GRAPH_RESOURCE = 'https://graph.microsoft.com'.freeze
-  SENDMAIL_ENDPOINT = '/v1.0/me/microsoft.graph.sendmail'.freeze
-  CONTENT_TYPE = 'application/json;odata.metadata=minimal;odata.streaming=true'.freeze
+  GRAPH_RESOURCE = 'https://graph.microsoft.com'
+  SENDMAIL_ENDPOINT = '/v1.0/me/microsoft.graph.sendmail'
+  CONTENT_TYPE = 'application/json;odata.metadata=minimal;odata.streaming=true'
 
   # Delegates the browser to the v2 authentication OmniAuth module
   # which takes the user to a sign-in page, if we don't have tokens already


### PR DESCRIPTION
We've decided never to upgrade to Ruby v3, so we don't have to freeze strings assigned to constants.